### PR TITLE
Feat: Prometheus metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ local_deploy_sybil: local_deploy_xrc
 local_upgrade: local_upgrade_xrc local_upgrade_sybil
 
 local_upgrade_xrc:
-	dfx canister install --mode upgrade --wasm ./xrc.wasm xrc 
+	dfx canister install --mode upgrade --wasm ./xrc.wasm.gz xrc 
 
 local_upgrade_sybil:
 	dfx build sybil 

--- a/src/sybil/src/http/handlers.rs
+++ b/src/sybil/src/http/handlers.rs
@@ -41,6 +41,12 @@ pub async fn get_asset_data_with_proof_request(req: HttpRequest) -> HttpResponse
     }
 }
 
+pub async fn gather_metrics() -> HttpResponse {
+    let data = crate::utils::metrics::gather_metrics();
+
+    response::ok(data)
+}
+
 #[inline(always)]
 async fn _get_asset_data_request(req: HttpRequest, with_signature: bool) -> Result<Vec<u8>> {
     let service = HTTP_SERVICE.get().expect("State not initialized");

--- a/src/sybil/src/http/mod.rs
+++ b/src/sybil/src/http/mod.rs
@@ -44,7 +44,14 @@ impl HttpService {
     }
 
     pub fn init_query_router() -> HttpRouter {
-        let router = Router::<Handler>::new();
+        let mut router = Router::<Handler>::new();
+
+        router
+            .insert(
+                "/metrics:query",
+                Box::new(|_| Box::pin(handlers::gather_metrics())),
+            )
+            .expect("Failed to insert handler");
 
         let pre_middlewares: Vec<PreMiddleware> = vec![];
 

--- a/src/sybil/src/http/response.rs
+++ b/src/sybil/src/http/response.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use serde_json::json;
 
 use crate::types::http::HttpResponse;
@@ -10,8 +8,7 @@ pub fn ok(body: Vec<u8>) -> HttpResponse {
         status_code: 200,
         upgrade: Some(false),
         headers: vec![("content-type".into(), "application/json".into())],
-        body: Cow::Owned(serde_bytes::ByteBuf::from(body)),
-        streaming_strategy: None,
+        body: serde_bytes::ByteBuf::from(body),
     }
 }
 
@@ -25,8 +22,7 @@ pub fn bad_request(msg: String) -> HttpResponse {
         status_code: 400,
         upgrade: Some(false),
         headers: vec![("content-type".into(), "application/json".into())],
-        body: Cow::Owned(serde_bytes::ByteBuf::from(error.to_string().as_bytes())),
-        streaming_strategy: None,
+        body: serde_bytes::ByteBuf::from(error.to_string().as_bytes()),
     }
 }
 
@@ -36,7 +32,6 @@ pub fn page_not_found(upgrade: bool) -> HttpResponse {
         status_code: 404,
         upgrade: Some(upgrade),
         headers: vec![],
-        body: Cow::Owned(serde_bytes::ByteBuf::from("Page not found".as_bytes())),
-        streaming_strategy: None,
+        body: serde_bytes::ByteBuf::from("Page not found".as_bytes()),
     }
 }

--- a/src/sybil/src/http/router.rs
+++ b/src/sybil/src/http/router.rs
@@ -50,8 +50,6 @@ impl<H> Router<H> {
     pub fn at(&self, key: &str) -> Option<RouterMatch<H>> {
         let splitted_key = key.split('?').collect::<Vec<&str>>();
 
-        println!("{:?}", splitted_key);
-
         let params = splitted_key.last().expect("invalid key");
 
         let key = splitted_key.first().expect("invalid key").to_string();

--- a/src/sybil/src/methods/custom_pairs.rs
+++ b/src/sybil/src/methods/custom_pairs.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use validator::{Validate, ValidationErrors};
 
 use crate::log;
+use crate::metrics;
 use crate::{
     types::{
         pairs::{Pair, PairError, PairsStorage, Source},
@@ -75,6 +76,8 @@ pub async fn _create_custom_pair(req: CreateCustomPairRequest) -> Result<(), Cus
     PairsStorage::get_custom_rate(&pair, &req.sources).await?;
     PairsStorage::add(pair);
 
+    metrics!(inc CUSTOM_PAIRS);
+
     log!(
         "[PAIRS] custom pair created. id: {}, owner: {}",
         req.pair_id,
@@ -108,6 +111,7 @@ pub async fn _remove_custom_pair(
 
         PairsStorage::remove(&id);
 
+        metrics!(dec CUSTOM_PAIRS);
         log!("[PAIRS] custom pair removed. id: {}, owner: {}", id, addr);
         return Ok(());
     }

--- a/src/sybil/src/methods/default_pairs.rs
+++ b/src/sybil/src/methods/default_pairs.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use validator::Validate;
 
 use crate::{
-    log,
+    log, metrics,
     types::{
         pairs::{Pair, PairError, PairsStorage},
         whitelist::WhitelistError,
@@ -54,6 +54,7 @@ async fn _create_default_pair(req: CreateDefaultPairRequest) -> Result<(), Defau
     PairsStorage::get_default_rate(&pair).await?;
     PairsStorage::add(pair);
 
+    metrics!(inc DEFAULT_PAIRS);
     log!("[PAIRS] default pair added. Pair ID: {}", req.pair_id);
     Ok(())
 }
@@ -73,6 +74,7 @@ async fn _remove_default_pair(id: String) -> Result<(), DefaultPairError> {
 
     PairsStorage::remove(&id);
 
+    metrics!(dec DEFAULT_PAIRS);
     log!("[PAIRS] default pair removed. Pair ID: {}", id);
     Ok(())
 }

--- a/src/sybil/src/methods/mod.rs
+++ b/src/sybil/src/methods/mod.rs
@@ -16,6 +16,7 @@ use ic_utils::{
 };
 
 use crate::{
+    metrics,
     types::{
         pairs::{Pair, PairError, PairsStorage},
         rate_data::RateDataLight,
@@ -50,7 +51,11 @@ pub async fn get_asset_data_with_proof(pair_id: String) -> Result<RateDataLight,
 }
 
 pub async fn _get_asset_data_with_proof(pair_id: String) -> Result<RateDataLight, AssetsError> {
-    Ok(PairsStorage::rate(&pair_id, true).await?)
+    metrics!(inc GET_ASSET_DATA_WITH_PROOF_CALLS, pair_id);
+    let rate = PairsStorage::rate(&pair_id, true).await?;
+
+    metrics!(inc SUCCESSFUL_GET_ASSET_DATA_WITH_PROOF_CALLS, pair_id);
+    Ok(rate)
 }
 
 #[update]
@@ -61,10 +66,12 @@ pub async fn get_asset_data(pair_id: String) -> Result<RateDataLight, String> {
 }
 
 async fn _get_asset_data(pair_id: String) -> Result<RateDataLight, AssetsError> {
+    metrics!(inc GET_ASSET_DATA_CALLS, pair_id);
     let mut rate = PairsStorage::rate(&pair_id, false).await?;
 
     rate.signature = None;
 
+    metrics!(inc SUCCESSFUL_GET_ASSET_DATA_CALLS, pair_id);
     Ok(rate)
 }
 

--- a/src/sybil/src/types/http.rs
+++ b/src/sybil/src/types/http.rs
@@ -1,8 +1,6 @@
-use std::borrow::Cow;
-
 use candid::{CandidType, Func};
 use serde::Deserialize;
-use serde_bytes::{ByteBuf, Bytes};
+use serde_bytes::ByteBuf;
 
 pub type HeaderField = (String, String);
 
@@ -33,6 +31,5 @@ pub struct HttpResponse {
     pub status_code: u16,
     pub upgrade: Option<bool>,
     pub headers: Vec<HeaderField>,
-    pub body: Cow<'static, Bytes>,
-    pub streaming_strategy: Option<StreamingStrategy>,
+    pub body: ByteBuf,
 }

--- a/src/sybil/src/utils/macros.rs
+++ b/src/sybil/src/utils/macros.rs
@@ -1,9 +1,12 @@
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => {{
+        use crate::metrics;
         ic_cdk::println!($($arg)*);
         ic_utils::logger::log_message(format!($($arg)*));
         ic_utils::monitor::collect_metrics();
+
+        metrics!(set CYCLES, ic_cdk::api::canister_balance() as u128);
     }};
 }
 

--- a/src/sybil/src/utils/metrics.rs
+++ b/src/sybil/src/utils/metrics.rs
@@ -223,7 +223,7 @@ thread_local! {
             ),
         SUCCESSFUL_GET_ASSET_DATA_CALLS: Metric::new(
                 "successful_get_asset_data_calls",
-                "Number of successfully returned get_asset_data calls.",
+                "Number of successfully returned get_asset_data calls",
                 "counter",
                 &["pair"],
             ),
@@ -235,7 +235,7 @@ thread_local! {
             ),
         SUCCESSFUL_GET_ASSET_DATA_WITH_PROOF_CALLS: Metric::new(
                 "successful_get_asset_data_with_proof_calls",
-                "Number of successfully returned get_asset_data_with_proof calls.",
+                "Number of successfully returned get_asset_data_with_proof calls",
                 "counter",
                 &["pair"],
             ),
@@ -259,7 +259,7 @@ thread_local! {
             ),
         SUCCESSFUL_XRC_CALLS: Metric::new(
                 "successful_xrc_calls",
-                "Number of successfully returned xrc calls. Note that this metric is about ic communication with the sybil canister. Meaning if sybil returns error, this metric will not be incremented. If ic returns error while quering sybil canister, this metric will be incremented.",
+                "Number of successfully returned xrc calls",
                 "counter",
                 &[],
             ),

--- a/src/sybil/src/utils/metrics.rs
+++ b/src/sybil/src/utils/metrics.rs
@@ -1,0 +1,366 @@
+use std::{cell::RefCell, collections::HashMap, io};
+
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct Metric {
+    pub name: String,
+    pub help: String,
+    pub typ: String,
+    pub label_names: Vec<String>,
+    pub inner: HashMap<Vec<String>, Vec<Inner>>,
+}
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct Inner {
+    pub value: u128,
+    pub label_values: Vec<String>,
+}
+
+#[allow(unused)]
+impl Inner {
+    pub fn new(value: u128, label_values: Vec<String>) -> Self {
+        Self {
+            value,
+            label_values,
+        }
+    }
+
+    pub fn inc(&mut self) {
+        self.value = self.value.saturating_add(1);
+    }
+
+    pub fn dec(&mut self) {
+        self.value = self.value.saturating_sub(1);
+    }
+
+    pub fn set(&mut self, value: u128) {
+        self.value = value;
+    }
+
+    pub fn get(&self) -> u128 {
+        self.value
+    }
+
+    pub fn inc_by(&mut self, value: u128) {
+        self.value = self.value.saturating_add(value);
+    }
+
+    pub fn dec_by(&mut self, value: u128) {
+        self.value = self.value.saturating_sub(value);
+    }
+}
+
+#[allow(unused)]
+impl Metric {
+    pub fn new(name: &str, help: &str, typ: &str, label_names: &[&str]) -> Self {
+        let label_names = label_names.iter().map(|s| s.to_string()).collect();
+        Self {
+            name: name.to_string(),
+            help: help.to_string(),
+            typ: typ.to_string(),
+            label_names,
+            inner: HashMap::new(),
+        }
+    }
+
+    pub fn inc(&mut self) {
+        self.inc_by(1);
+    }
+
+    pub fn inc_by(&mut self, val: u128) {
+        self.inner
+            .entry(vec![])
+            .or_insert_with(|| vec![Inner::new(val, vec![])])
+            .first_mut()
+            .expect("should be here")
+            .inc_by(val);
+    }
+
+    pub fn dec(&mut self) {
+        self.dec_by(1);
+    }
+
+    pub fn dec_by(&mut self, val: u128) {
+        self.inner
+            .entry(vec![])
+            .or_insert_with(|| vec![Inner::new(0, vec![])])
+            .first_mut()
+            .expect("should be here")
+            .dec_by(val);
+    }
+
+    pub fn set(&mut self, value: u128) {
+        self.inner
+            .entry(vec![])
+            .or_insert_with(|| vec![Inner::new(value, vec![])])
+            .first_mut()
+            .expect("should be here")
+            .set(value);
+    }
+
+    pub fn get(&self) -> u128 {
+        self.inner
+            .get(&vec![])
+            .map(|inner_vec| inner_vec.first().unwrap().value)
+            .unwrap_or(0)
+    }
+
+    fn check_label_values(&self, label_values: &[String]) {
+        if label_values.len() != self.label_names.len() {
+            panic!(
+                "Invalid number of labels. Expected {}, got {}",
+                self.label_names.len(),
+                label_values.len()
+            )
+        }
+    }
+
+    pub fn with_label_values(&mut self, label_values: Vec<String>) -> &mut Inner {
+        self.check_label_values(&label_values);
+
+        self.inner
+            .entry(label_values.clone())
+            .or_insert_with(|| vec![Inner::new(0, label_values)])
+            .first_mut()
+            .unwrap()
+    }
+
+    fn encode_header<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+        writeln!(w, "# HELP {} {}", self.name, self.help)?;
+        writeln!(w, "# TYPE {} {}", self.name, self.typ)
+    }
+
+    fn encode_value<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+        for (label_values, inner_vec) in self.inner.iter() {
+            if label_values.len() != self.label_names.len() {
+                continue;
+            }
+
+            if label_values.is_empty() {
+                writeln!(w, "{} {}", self.name, inner_vec.first().unwrap().value)?;
+                return Ok(());
+            }
+
+            for inner in inner_vec {
+                let labels = self
+                    .label_names
+                    .iter()
+                    .zip(label_values.iter())
+                    .map(|(label_name, label_value)| format!("{}=\"{}\"", label_name, label_value))
+                    .collect::<Vec<String>>()
+                    .join(",");
+
+                writeln!(w, "{}{{{}}} {}", self.name, labels, inner.value)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn encode<W: io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+        if self.inner.is_empty() {
+            return Ok(());
+        }
+
+        self.encode_header(w)?;
+        self.encode_value(w)
+    }
+}
+
+#[allow(non_snake_case)]
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct Metrics {
+    pub CUSTOM_PAIRS: Metric,
+    pub DEFAULT_PAIRS: Metric,
+    pub GET_ASSET_DATA_CALLS: Metric,
+    pub SUCCESSFUL_GET_ASSET_DATA_CALLS: Metric,
+    pub GET_ASSET_DATA_WITH_PROOF_CALLS: Metric,
+    pub SUCCESSFUL_GET_ASSET_DATA_WITH_PROOF_CALLS: Metric,
+    pub FALLBACK_XRC_CALLS: Metric,
+    pub SUCCESSFUL_FALLBACK_XRC_CALLS: Metric,
+    pub XRC_CALLS: Metric,
+    pub SUCCESSFUL_XRC_CALLS: Metric,
+    pub CYCLES: Metric,
+}
+
+impl Metrics {
+    pub fn encode<W: io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+        self.CUSTOM_PAIRS.encode(w)?;
+        self.DEFAULT_PAIRS.encode(w)?;
+        self.GET_ASSET_DATA_CALLS.encode(w)?;
+        self.SUCCESSFUL_GET_ASSET_DATA_CALLS.encode(w)?;
+        self.GET_ASSET_DATA_WITH_PROOF_CALLS.encode(w)?;
+        self.SUCCESSFUL_GET_ASSET_DATA_WITH_PROOF_CALLS.encode(w)?;
+        self.FALLBACK_XRC_CALLS.encode(w)?;
+        self.SUCCESSFUL_FALLBACK_XRC_CALLS.encode(w)?;
+        self.XRC_CALLS.encode(w)?;
+        self.SUCCESSFUL_XRC_CALLS.encode(w)?;
+        self.CYCLES.encode(w)
+    }
+}
+
+thread_local! {
+    pub static METRICS: RefCell<Metrics> = RefCell::new(Metrics{
+        CUSTOM_PAIRS: Metric::new(
+                "custom_pairs",
+                "Number of custom pairs",
+                "gauge",
+                &[],
+            ),
+        DEFAULT_PAIRS: Metric::new(
+                "default_pairs",
+                "Number of default pairs",
+                "gauge",
+                &[],
+            ),
+        GET_ASSET_DATA_CALLS: Metric::new(
+                "get_asset_data_calls",
+                "Number of get_asset_data calls",
+                "counter",
+                &["pair"],
+            ),
+        SUCCESSFUL_GET_ASSET_DATA_CALLS: Metric::new(
+                "successful_get_asset_data_calls",
+                "Number of successfully returned get_asset_data calls.",
+                "counter",
+                &["pair"],
+            ),
+        GET_ASSET_DATA_WITH_PROOF_CALLS: Metric::new(
+                "get_asset_data_with_proof_calls",
+                "Number of get_asset_data_with_proof calls",
+                "counter",
+                &["pair"],
+            ),
+        SUCCESSFUL_GET_ASSET_DATA_WITH_PROOF_CALLS: Metric::new(
+                "successful_get_asset_data_with_proof_calls",
+                "Number of successfully returned get_asset_data_with_proof calls.",
+                "counter",
+                &["pair"],
+            ),
+        FALLBACK_XRC_CALLS: Metric::new(
+                "fallback_xrc_calls",
+                "Number of fallback_xrc calls",
+                "counter",
+                &[],
+            ),
+        SUCCESSFUL_FALLBACK_XRC_CALLS: Metric::new(
+                "fallback_xrc_calls",
+                "Number of fallback_xrc calls",
+                "counter",
+                &[],
+            ),
+        XRC_CALLS: Metric::new(
+                "xrc_calls",
+                "Number of xrc calls",
+                "counter",
+                &[],
+            ),
+        SUCCESSFUL_XRC_CALLS: Metric::new(
+                "successful_xrc_calls",
+                "Number of successfully returned xrc calls. Note that this metric is about ic communication with the sybil canister. Meaning if sybil returns error, this metric will not be incremented. If ic returns error while quering sybil canister, this metric will be incremented.",
+                "counter",
+                &[],
+            ),
+        CYCLES: Metric::new(
+                "cycles",
+                "Number of cycles",
+                "gauge",
+                &[],
+            ),
+    });
+}
+
+pub fn gather_metrics() -> Vec<u8> {
+    let mut buffer = vec![];
+
+    METRICS.with(|m| m.borrow().encode(&mut buffer).unwrap());
+
+    buffer
+}
+
+#[macro_export]
+macro_rules! metrics {
+    ( inc $metric:ident ) => {
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.inc());
+    };
+
+    ( inc_by $metric:ident, $val:ident ) => {
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.inc_by($val as u128));
+    };
+
+    ( inc $metric:ident, $($labels:expr),+) => {{
+        let lbls: Vec<String> = vec![$(format!("{}", $labels)),+];
+
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(lbls).inc());
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(vec!["all".to_string()]).inc());
+    }};
+
+
+    ( dec $metric:ident ) => {
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.dec());
+    };
+
+    ( dec_by $metric:ident, $val:ident ) => {
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.dec_by($val as u128));
+    };
+
+    ( dec $metric:ident, $($labels:expr),+) => {
+        let lbls: Vec<String> = vec![$(format!("{}", $labels)),+];
+
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(lbls).dec());
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(vec!["all".to_string()]).dec());
+    };
+
+
+    ( get $metric:ident ) => {
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.get())
+    };
+
+    ( get $metric:ident, $($labels:expr),+) => {
+        {
+            let lbls: Vec<String> = vec![$(format!("{}", $labels)),+];
+
+            $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(lbls).get())
+        }
+    };
+
+    ( timer $metric:ident, $($labels:expr),+) => {
+        let lbls: Vec<String> = vec![$(format!("{}", $labels)),+];
+
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(lbls).start_timer());
+    };
+
+    ( timer $metric:ident) => {
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.start_timer())
+    };
+
+    ( timer observe $timer:ident) => {
+        $timer.observe_duration()
+    };
+
+    ( timer discard $timer:ident) => {
+        $timer.stop_and_discard()
+    };
+
+    ( set $metric:ident, $val:expr ) => {
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.set($val as u128));
+    };
+
+    ( set $metric:ident, $val:expr, $($labels:expr),+) => {
+        let lbls: Vec<String> = vec![$(format!("{}", $labels)),+];
+
+        let prev_val = $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(lbls.clone()).get());
+
+        let diff = $val as i128 - prev_val as i128;
+
+
+        $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(lbls).set($val as u128));
+        if diff < prev_val as i128 {
+            $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(vec!["all".to_string()]).dec_by(diff as u128));
+        } else {
+            $crate::utils::metrics::METRICS.with(|m| m.borrow_mut().$metric.with_label_values(vec!["all".to_string()]).inc_by(diff as u128));
+        }
+    };
+}

--- a/src/sybil/src/utils/mod.rs
+++ b/src/sybil/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod canister;
 pub mod convertion;
 pub mod encoding;
 pub mod macros;
+pub mod metrics;
 pub mod nat;
 pub mod processors;
 pub mod signature;


### PR DESCRIPTION
<h1> What's new </h1>

Metrics added: 

* custom_pairs - Number of custom pairs
* default_pairs - Number of default pairs
* get_asset_data_calls - Number of get_asset_data calls per pair_id
* successful_get_asset_data_calls - Number of successfully returned get_asset_data calls per pair_id
* get_asset_data_with_proof_calls - Number of get_asset_data_with_proof calls per pair_id
* successful_get_asset_data_with_proof_calls - Number of successfully returned get_asset_data_with_proof calls per pair_id
* fallback_xrc_calls - Number of fallback_xrc calls
* successful_fallback_xrc_calls - Number of successfuly returned fallback_xrc calls
* xrc_calls - Number of xrc calls
* successful_xrc_calls - Number of successfully returned xrc calls
* cycles - Number of cycles
