### PR TITLE
Fix: empty sources fix

### DIFF
--- a/src/sybil/src/methods/mod.rs
+++ b/src/sybil/src/methods/mod.rs
@@ -42,7 +42,6 @@ fn get_feeds(
     pagination: Option<Pagination>,
 ) -> PaginationResult<Feed> {
     let mut feeds = FeedStorage::get_all(filter);
-    feeds.iter_mut().for_each(|feed| feed.shrink_sources());
 
     match pagination {
         Some(pagination) => {

--- a/src/sybil/src/types/feeds.rs
+++ b/src/sybil/src/types/feeds.rs
@@ -218,14 +218,6 @@ impl Feed {
     pub fn set_owner(&mut self, owner: Address) {
         self.owner = owner;
     }
-
-    pub fn shrink_sources(&mut self) {
-        if let Some(sources) = &mut self.sources {
-            sources.retain(|source| {
-                source.expected_bytes.is_some() && source.expected_bytes.unwrap() > 0
-            });
-        }
-    }
 }
 
 #[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]


### PR DESCRIPTION
<h1> What's new </h1> 

This PR fixes `get_feeds` method that returns feeds with empty source field. 