### PR TITLE
Use Orally RPC wrapper for all requests

### DIFF
--- a/src/sybil/src/methods/feed_methods/get_dxr_data.rs
+++ b/src/sybil/src/methods/feed_methods/get_dxr_data.rs
@@ -163,7 +163,7 @@ async fn get_dex<T: Transport + 'static>(
         return Ok(dex);
     }
 
-    let chain_rpc = ChainsRPC::get_first_chain_rpc_url(chain_id)?;
+    let chain_rpc = ChainsRPC::get_first_chain_rpc_url_with_wrapper(chain_id)?;
 
     let w3 = web3::batch_instance(chain_rpc, clone_with_state!(evm_rpc_canister), None);
 
@@ -347,7 +347,7 @@ pub async fn _get_dxr_data_batch(
     with_meta: bool,
     payer: Option<String>,
 ) -> Result<GetDXRDataBatchResult, CustomFeedError> {
-    let chain_rpc = ChainsRPC::get_first_chain_rpc(chain_id)?;
+    let chain_rpc = ChainsRPC::get_first_chain_rpc_with_wrapper(chain_id)?;
 
     // w3 optimized for getting the block number
     let w3_block = web3::instance(
@@ -486,7 +486,7 @@ pub async fn _get_dxr_data(
     payer: Option<String>,
 ) -> Result<GetDXRDataResult, CustomFeedError> {
     let balance_before = ic_cdk::api::canister_balance();
-    let chain_rpc = ChainsRPC::get_first_chain_rpc_url(chain_id)?;
+    let chain_rpc = ChainsRPC::get_first_chain_rpc_url_with_wrapper(chain_id)?;
 
     let w3 = web3::batch_instance(chain_rpc, clone_with_state!(evm_rpc_canister), None);
 

--- a/src/sybil/src/methods/feed_methods/read_contract.rs
+++ b/src/sybil/src/methods/feed_methods/read_contract.rs
@@ -142,7 +142,7 @@ pub async fn _read_contract(
         };
     }
 
-    let chain_rpc = ChainsRPC::get_first_chain_rpc_url(chain_id)?;
+    let chain_rpc = ChainsRPC::get_first_chain_rpc_url_with_wrapper(chain_id)?;
 
     let w3 = web3::instance(chain_rpc, clone_with_state!(evm_rpc_canister), None);
 

--- a/src/sybil/src/methods/feed_methods/read_logs.rs
+++ b/src/sybil/src/methods/feed_methods/read_logs.rs
@@ -138,7 +138,7 @@ pub async fn _read_logs(
         };
     }
 
-    let chain_rpc = ChainsRPC::get_first_chain_rpc_url(chain_id)?;
+    let chain_rpc = ChainsRPC::get_first_chain_rpc_url_with_wrapper(chain_id)?;
 
     let w3 = web3::instance(chain_rpc, clone_with_state!(evm_rpc_canister), None);
 

--- a/src/sybil/src/types/chains_rpc.rs
+++ b/src/sybil/src/types/chains_rpc.rs
@@ -143,6 +143,44 @@ impl ChainsRPC {
             .clone())
     }
 
+    pub fn get_first_chain_rpc_url_with_wrapper(chain_id: u64) -> Result<String, ChainsRPCError> {
+        let rpc_wrapper = crate::clone_with_state!(rpc_wrapper);
+        Ok(STATE
+            .with(|state| {
+                let state = state.borrow();
+                state
+                    .chains_rpc
+                    .0
+                    .get(&chain_id)
+                    .cloned()
+                    .ok_or(ChainsRPCError::ChainDoesNotExist)
+            })?
+            .first()
+            .map(|rpc| format!("{}{}", rpc_wrapper, rpc.get_url()))
+            .ok_or(ChainsRPCError::ChainDoesNotExist)?)
+    }
+    
+    pub fn get_first_chain_rpc_with_wrapper(chain_id: u64) -> Result<RPCUrl, ChainsRPCError> {
+        let rpc_wrapper = crate::clone_with_state!(rpc_wrapper);
+        Ok(STATE
+            .with(|state| {
+                let state = state.borrow();
+                state
+                    .chains_rpc
+                    .0
+                    .get(&chain_id)
+                    .cloned()
+                    .ok_or(ChainsRPCError::ChainDoesNotExist)
+            })?
+            .first()
+            .map(|rpc| {
+                let mut rpc = rpc.clone();
+                rpc.url = format!("{}{}", rpc_wrapper, rpc.get_url());
+                rpc
+            })
+            .ok_or(ChainsRPCError::ChainDoesNotExist)?)
+    }
+
     pub fn get_chain_rpc(chain_id: u64) -> Result<Vec<String>, ChainsRPCError> {
         Ok(STATE
             .with(|state| {


### PR DESCRIPTION
In this PR:
- wrap all RPC requests with Orally custom rpc-wrapper
- confirmed that all secrets are hidden from the users who are not controllers